### PR TITLE
update dependencies to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,20 +26,20 @@
     "test": "npm run lint"
   },
   "dependencies": {
-    "async": "~1.5.0",
+    "async": "~2.6.4",
     "chai": "~1.5.0",
     "concat-stream": "~1.5.1",
-    "get-pixels": "~3.2.3",
+    "get-pixels": "~3.3.3",
     "obj-extend": "~0.1.0",
     "semver": "~5.0.3",
     "vinyl": "~2.1.0"
   },
   "devDependencies": {
-    "foundry": "~4.3.2",
-    "foundry-release-git": "~2.0.2",
-    "foundry-release-npm": "~2.0.2",
-    "jscs": "~2.4.0",
-    "jshint": "~2.8.0",
+    "foundry": "~4.7.0",
+    "foundry-release-git": "~2.1.0",
+    "foundry-release-npm": "~2.1.0",
+    "jscs": "~2.11.0",
+    "jshint": "~2.13.4",
     "twolfson-style": "~1.6.1"
   },
   "keywords": [


### PR DESCRIPTION
The purpose is mainly to fix CVE-2021-43138 in async as well as
CVE-2020-8175 in jpeg-js, a dependency of get-pixels.